### PR TITLE
Fix pagination not working with multiple taxonomies

### DIFF
--- a/fields/class-gr-acf-field-multiple-taxonomy-v5.php
+++ b/fields/class-gr-acf-field-multiple-taxonomy-v5.php
@@ -130,6 +130,7 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 
 		// vars
 		$results = array();
+		$more = false;
 
 		foreach( $field['taxonomy'] as $taxonomy ) {
 
@@ -241,7 +242,10 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 
 			$results[] = $data;
 
-			if( count( $results, 1 ) >= $limit ) break;
+			if( count( $results, 1 ) >= $limit ) {
+				$more = true;
+				continue;
+			}
 
 		}
 
@@ -250,6 +254,7 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 		$response = array(
 			'results' => $results,
 			'limit'   => $limit,
+			'more'    => $more,
 		);
 
 


### PR DESCRIPTION
## Issue

When the 20 term limit is reached it simply exits without passing the `more` value in the response. Thus ACF doesn't load more items.

I'm guessing the basic select option shouldn't limit the terms at all since there's no ajax feature to load more items without the _select2_ component.

## Solution

This is not actually a proper solution since it now returns more items than the limit and the limit is per taxonomy so the total is much larger. Unfortunately I didn't have time to look into a proper fix here but leaving this PR as a draft in case someone wants a solution that at least loads all the terms rather than preventing them from loading.