### PR TITLE
ACF 6.3.10 compatibility fix for AJAX

### DIFF
--- a/fields/class-gr-acf-field-multiple-taxonomy-v5.php
+++ b/fields/class-gr-acf-field-multiple-taxonomy-v5.php
@@ -98,7 +98,8 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
         */
 		$action = 'acf_field_select_' . $key;
 		if ( ! wp_verify_nonce( sanitize_text_field( $nonce), $action ) ) {
-			return false;
+			wp_send_json_error();
+			die();
 		}
 
 		// get choices

--- a/fields/class-gr-acf-field-multiple-taxonomy-v5.php
+++ b/fields/class-gr-acf-field-multiple-taxonomy-v5.php
@@ -90,14 +90,19 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 		}
 
 		// validate
-		if ( ! acf_verify_ajax( $nonce, $key ) ) {
-			die();
+		/**
+		 *  In `acf_verify_ajax()`, the action is expected to be in this format: 'acf_field_' . $this->name . '_' . $key;
+		 * Because this field is ultimately rendered by the select field class, the nonce action used to create the
+		 * nonce is tied to 'select' instead of 'multiple_taxonomy'. So, here we set the action and then run our own
+		 * validation of the nonce.
+        */
+		$action = 'acf_field_select_' . $key;
+		if ( ! wp_verify_nonce( sanitize_text_field( $nonce), $action ) ) {
+			return false;
 		}
-
 
 		// get choices
 		$response = $this->get_ajax_query( $_POST );
-
 
 		// return
 		acf_send_ajax_results($response);
@@ -421,8 +426,7 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 
 		}
 
-
-    // Add choices and ajax
+        // Add choices and ajax
 		$field['choices'] = $choices;
 		$field['ajax'] = 1;
 		$field['ajax_action'] = 'acf/fields/multiple_taxonomy/query';
@@ -430,7 +434,7 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 		// Always enable "Stylized UI" option
 		$field['ui'] = 1;
 
-    // Let ACF handle the rest
+        // Let ACF handle the rest
 		return $field;
 	}
 


### PR DESCRIPTION
In [ACF 6.3.10](https://www.advancedcustomfields.com/changelog/), more changes were made to how AJAX requests are verified, which break `acf-multiple-taxonomy`'s AJAX verification implementation. Specifically, 
> Security - Field specific ACF nonces are now prefixed, resolving an issue where third party nonces could be treated as valid for AJAX calls

Now, each nonce is scoped to the field (and field type) that it was created for.

In the case of `acf-multiple-taxonomy`, the rendering is done by the select field class's `render_field()`, which is where the nonce is created. So, when it's time to verify the nonce, the expected action includes `_select_`, but the derived action included `_multiple_taxonomy_`. 

In this PR, we manually build the expected action, and then use WP's built in nonce verification, so as to skip the `acf_verify_ajax()` call that derives the wrong action.

Because this isn't documented in ACF's documentation very well, I left a large PHP comment in the code. It's, of course, up to you whether you want to leave that in there.

Hope this works to get everyone up and running again!