### PR TITLE
Fixed multiple selection ajax scroll not pulling additional results

### DIFF
--- a/fields/class-gr-acf-field-multiple-taxonomy-v5.php
+++ b/fields/class-gr-acf-field-multiple-taxonomy-v5.php
@@ -261,7 +261,7 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 
 			$results[] = $data;
 
-			if( count( $results, 1 ) >= $limit ) break;
+			if( count( $results, 1 ) >= $limit ) continue;
 
 		}
 


### PR DESCRIPTION
Fixes a problem where the AJAX call does not load more results, apparently because the loading of additional results is interrupted by a "break" inside of a foreach loop, instead of a "continue".
See related comment on the issue: https://github.com/game-ryo/acf-multiple-taxonomy/issues/3#issuecomment-2878099161