### PR TITLE
Add unescape param to term title

### DIFF
--- a/fields/class-gr-acf-field-multiple-taxonomy-v5.php
+++ b/fields/class-gr-acf-field-multiple-taxonomy-v5.php
@@ -236,7 +236,7 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 			foreach( $data['terms'] as $term ) {
 				$result['children'][] = array(
 					'id'   => $term->term_id,
-					'text' => $this->get_term_title( $term, $field, $options['post_id'] )
+					'text' => $this->get_term_title( $term, $field, $options['post_id'], true )
 				);
 			}
 
@@ -478,13 +478,19 @@ class gr_acf_field_multiple_taxonomy extends acf_field {
 	 * @param	WP_Term $term The term object.
 	 * @param	array $field The field settings.
 	 * @param	mixed $post_id The post_id being edited.
+	 * @param   boolean $unescape Should we return an unescaped post title.
 	 * @return	string
 	 */
-	function get_term_title( $term, $field, $post_id = 0 ) {
+	function get_term_title( $term, $field, $post_id = 0, $unescape = false ) {
 		$title = acf_get_term_title( $term );
 
 		// Default $post_id to current post being edited.
 		$post_id = $post_id ? $post_id : acf_get_form_data('post_id');
+
+		// unescape for select2 output which handles the escaping.
+		if ( $unescape ) {
+			$title = html_entity_decode( $title );
+		}
 
 		/**
 		 * Filters the term title.


### PR DESCRIPTION
This change adds an `$unescape` parameter to the `get_term_title()` function so that terms with html entities (`&amp;`, `&apos;`, etc.) will render appropriately in the field.

This mimics what ACF does for their taxonomy field:

https://github.com/AdvancedCustomFields/acf/blob/1717327eafd0a245d44d23e7c7c1a04cc19c0d44/includes/fields/class-acf-field-taxonomy.php#L209

This fixes a bug where terms that contain special html characters render with their html entities:

<img width="397" alt="Screenshot 2025-07-08 at 5 23 53 PM" src="https://github.com/user-attachments/assets/39419ec9-521a-4214-896c-8db40d5b53e5" />
